### PR TITLE
fix: parsing success/error reponse version field fixed

### DIFF
--- a/lib/src/models/network/liqpay_error_response.dart
+++ b/lib/src/models/network/liqpay_error_response.dart
@@ -5,14 +5,14 @@ import 'package:liqpay/liqpay.dart';
 class LiqPayErrorResponse extends LiqPayResponse {
   final String? errorCode;
   final String? errorDescription;
-  LiqPayErrorResponse(super.result, super.status, super.version,
-      super.action, this.errorCode, this.errorDescription);
+  LiqPayErrorResponse(super.result, super.status, super.version, super.action,
+      this.errorCode, this.errorDescription);
 
   factory LiqPayErrorResponse.fromJson(Map<String, dynamic> json) =>
       LiqPayErrorResponse(
         json['result'] as String,
         json['status'] as String,
-        json['version'] as String,
+        json['version'].toString(),
         LiqPayAction.fromValue(json['action']),
         json['err_code'] as String?,
         json['err_description'] as String?,

--- a/lib/src/models/network/liqpay_success_response.dart
+++ b/lib/src/models/network/liqpay_success_response.dart
@@ -10,7 +10,7 @@ class LiqPaySuccessResponse extends LiqPayResponse {
       LiqPaySuccessResponse(
         json['result'] as String,
         json['status'] as String,
-        json['version'] as String,
+        json['version'].toString(),
         LiqPayAction.fromValue(json['action']),
       );
 }


### PR DESCRIPTION
Hi, thank you for your great package!
I've build the example app and have got an error in success response parser. The version field which comes from API is now integer and not String.
Because we don't really need that field I've just used toString() method instead of changing types of the response
![Screenshot_15](https://github.com/Newgarden-Solutions/liqpay/assets/107860068/24ce1a5d-4785-4e0d-aad2-4c2a834da77c)
